### PR TITLE
add 2 bits of aerosol QA to Fmask

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# espa-surface-reflectanc-v3.1.0
-FROM 018923174646.dkr.ecr.us-west-2.amazonaws.com/hls-base-c2
+FROM 018923174646.dkr.ecr.us-west-2.amazonaws.com/hls-base-3.0.5
 ENV PREFIX=/usr/local \
     SRC_DIR=/usr/local/src \
     GCTPLIB=/usr/local/lib \

--- a/scripts/landsat.sh
+++ b/scripts/landsat.sh
@@ -117,7 +117,8 @@ convert_espa_to_hdf --xml="$hls_espa_xml" --hdf="$srhdf"
 
 # Run addFmaskSDS
 echo "Run addFmaskSDS"
-addFmaskSDS "$srhdf" "$fmaskbin" "$mtl" "$ACCODE" "$outputhdf"
+aerosol_qa="${granuledir}/${granule}_sr_aerosol.IMG"
+addFmaskSDS "$srhdf" "$fmaskbin" "$aerosol_qa" "$mtl" "$ACCODE" "$outputhdf"
 
 if [ -z "$debug_bucket" ]; then
   aws s3 cp "${outputhdf}" "s3://${bucket}/${outputname}.hdf"


### PR DESCRIPTION
The USGS aerosol QA was incorporated into Fmask.   To do this,  the USGS aerosol QA file is added to the coommandline parameters for addFmaskSDS.    Specifically, the aerosol QA filename is to inserted after the Fmask binary filename:
       ./addFmaskSDS    $lasrcL8hdf \
                                       $fmaskbin \
                                       $aerosolQA
                                       $MTLfile \
                                       $ACCODE \
                                       $outfile

A USGS aerosol QA file has a name like this: LC08_L1TP_229082_20200606_20200824_02_T1_sr_aerosol.img
