### PR TITLE
chore: bump hls-landsat to hls-base@v3.5.2 for consistency with hls-sentinel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV PREFIX=/usr/local \
     HDFLINK=" -lmfhdf -ldf -lm" \
     ECS_ENABLE_TASK_IAM_ROLE=true \
     PYTHONPATH="${PYTHONPATH}:${PREFIX}/lib/python3.6/site-packages" \
-    ACCODE=LaSRCL8V3.5.1 \
+    ACCODE="LaSRC v3.5.2" \
     LC_ALL=en_US.utf-8 \
     LANG=en_US.utf-8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 018923174646.dkr.ecr.us-west-2.amazonaws.com/hls-base-3.5.2
+FROM 018923174646.dkr.ecr.us-west-2.amazonaws.com/hls-base:v3.5.2
 ENV PREFIX=/usr/local \
     SRC_DIR=/usr/local/src \
     GCTPLIB=/usr/local/lib \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 018923174646.dkr.ecr.us-west-2.amazonaws.com/hls-base-3.5.1
+FROM 018923174646.dkr.ecr.us-west-2.amazonaws.com/hls-base-3.5.2
 ENV PREFIX=/usr/local \
     SRC_DIR=/usr/local/src \
     GCTPLIB=/usr/local/lib \

--- a/scripts/landsat.sh
+++ b/scripts/landsat.sh
@@ -13,7 +13,7 @@ prefix="$PREFIX"
 workingdir="/var/scratch/${jobid}"
 granuledir="${workingdir}/${granule}"
 # shellcheck disable=2153
-ACCODE=Lasrc
+ACCODE="LaSRC v3.5.2"
 
 # Remove tmp files on exit
 # shellcheck disable=2064


### PR DESCRIPTION
This PR updates the `hls-base` container to `v3.5.2` following https://github.com/NASA-IMPACT/hls-sentinel/pull/167

This is a no-op from a code perspective for Landsat because the `hls-base@v3.5.2` container only includes a code change for LaSRC that applies to the Sentinel-2 code path. The intention here is to keep our Landsat and Sentinel-2 containers using the same base image for consistency