### PR TITLE
fix: revert to hls-base-3.5.1 with Fmask 4.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 018923174646.dkr.ecr.us-west-2.amazonaws.com/hls-base:v3.5.1
+FROM 018923174646.dkr.ecr.us-west-2.amazonaws.com/hls-base-3.5.1
 ENV PREFIX=/usr/local \
     SRC_DIR=/usr/local/src \
     GCTPLIB=/usr/local/lib \


### PR DESCRIPTION
This PR reverts part of the change in https://github.com/NASA-IMPACT/hls-landsat/commit/bcc35314fdef1246297f52597d775bb8a6ec5a68 to put our `hls-base` back on the build with Fmask 4.6