### PR TITLE
fix: hls-base with rebuilt Fmask v4_7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 018923174646.dkr.ecr.us-west-2.amazonaws.com/hls-base:40
+FROM 018923174646.dkr.ecr.us-west-2.amazonaws.com/hls-base:v3.5.1.0
 ENV PREFIX=/usr/local \
     SRC_DIR=/usr/local/src \
     GCTPLIB=/usr/local/lib \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 018923174646.dkr.ecr.us-west-2.amazonaws.com/hls-base-3.5.1
+FROM 018923174646.dkr.ecr.us-west-2.amazonaws.com/hls-base:40
 ENV PREFIX=/usr/local \
     SRC_DIR=/usr/local/src \
     GCTPLIB=/usr/local/lib \
@@ -13,7 +13,7 @@ ENV PREFIX=/usr/local \
     HDFLINK=" -lmfhdf -ldf -lm" \
     ECS_ENABLE_TASK_IAM_ROLE=true \
     PYTHONPATH="${PYTHONPATH}:${PREFIX}/lib/python3.6/site-packages" \
-    ACCODE="LaSRC v3.5.1" \
+    ACCODE="LaSRC v3.5.1.0" \
     LC_ALL=en_US.utf-8 \
     LANG=en_US.utf-8
 


### PR DESCRIPTION
Rebuilding with `hls-base` from this PR, https://github.com/NASA-IMPACT/hls-base/pull/40#issue-2939182939

This change allows us to use the same `hls-base` container with the Fmask update for Sentinel-2C and the bugfix for LaSRC from 3.5.1.0 (`.0` being our first fork of `3.5.1`)